### PR TITLE
SC-13894 Upgrade Jenkins to newer version and install required plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - image: "Dockerfile"
-            tags: [ "spryker/jenkins-boilerplate:2.401.2", "spryker/jenkins-boilerplate:latest" ]
+            tags: [ "spryker/jenkins-boilerplate:2.401.3", "spryker/jenkins-boilerplate:latest" ]
             platforms: [ "linux/amd64", "linux/arm64" ]
     steps:
       - name: Set up QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - image: "Dockerfile"
-            tags: [ "spryker/jenkins-boilerplate:2.387.1", "spryker/jenkins-boilerplate:latest" ]
+            tags: [ "spryker/jenkins-boilerplate:2.401.2", "spryker/jenkins-boilerplate:latest" ]
             platforms: [ "linux/amd64", "linux/arm64" ]
     steps:
       - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG JENKINS_VERSION=2.401.2
+ARG JENKINS_VERSION=2.401.3
 
 FROM jenkins/jenkins:${JENKINS_VERSION} as jenkins_cli
 USER root
@@ -16,7 +16,7 @@ RUN curl -sSL https://github.com/newrelic/nr-jenkins-plugin/releases/download/v$
     cp /tmp/nr-jenkins-plugin/new-relic.hpi /usr/share/jenkins/ref/plugins/
 
 # As we just use the artefacts a smaller image can be used as final target
-FROM alpine:latest 
+FROM alpine:latest
 COPY --from=jenkins /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/plugins
 COPY --from=jenkins /usr/share/jenkins/jenkins.war /usr/share/jenkins/jenkins.war
 COPY --from=jenkins_cli /usr/share/jenkins/jenkins-cli.jar /usr/share/jenkins/jenkins-cli.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,8 @@ RUN curl -sSL https://github.com/newrelic/nr-jenkins-plugin/releases/download/v$
     jenkins-plugin-cli --plugin-file /tmp/plugins.txt && bash -c "jenkins.sh &" && \
     cp /tmp/nr-jenkins-plugin/new-relic.hpi /usr/share/jenkins/ref/plugins/
 
+# As we just use the artefacts a smaller image can be used as final target
+FROM alpine:latest 
+COPY --from=jenkins /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/plugins
+COPY --from=jenkins /usr/share/jenkins/jenkins.war /usr/share/jenkins/jenkins.war
 COPY --from=jenkins_cli /usr/share/jenkins/jenkins-cli.jar /usr/share/jenkins/jenkins-cli.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,4 @@ RUN curl -sSL https://github.com/newrelic/nr-jenkins-plugin/releases/download/v$
     jenkins-plugin-cli --plugin-file /tmp/plugins.txt && bash -c "jenkins.sh &" && \
     cp /tmp/nr-jenkins-plugin/new-relic.hpi /usr/share/jenkins/ref/plugins/
 
-# As we just use the artefacts a smaller image can be used as final target
-FROM alpine:latest 
-COPY --from=jenkins /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/plugins
-COPY --from=jenkins /usr/share/jenkins/jenkins.war /usr/share/jenkins/jenkins.war
 COPY --from=jenkins_cli /usr/share/jenkins/jenkins-cli.jar /usr/share/jenkins/jenkins-cli.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG JENKINS_VERSION=2.387.1
+ARG JENKINS_VERSION=2.401.2
 
 FROM jenkins/jenkins:${JENKINS_VERSION} as jenkins_cli
 USER root

--- a/plugins.txt
+++ b/plugins.txt
@@ -2,7 +2,9 @@ metrics:4.2.13-420.vea_2f17932dd6
 credentials:1224.vc23ca_a_9a_2cb_0
 token-macro:321.vd7cc1f2a_52c8
 snakeyaml-api:1.33-95.va_b_a_e3e47b_fa_4
-jackson2-api:2.14.2-319.v37853346a_229
+jackson2-api:2.15.1-344.v6eb_55303dc3e
 variant:59.vf075fe829ccb
 workflow-step-api:639.v6eca_cd8c04a_a_
 configuration-as-code:1616.v11393eccf675
+throttle-concurrents:2.14
+PrioritySorter:5.0.0


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-13894

#### Related resources

- https://github.com/spryker/docker-jenkins/pull/9
- https://github.com/spryker/docker-sdk/pull/454
- https://github.com/spryker/suite-nonsplit/pull/8055

#### Change log

- update Jenkins version to 2.401.2
- update jackson2-api plugin to 2.15.1-344.v6eb_55303dc3e
- install throttle-concurrents:2.14
- install PrioritySorter:5.0.0
